### PR TITLE
[OI] Check redis-server exists in process table without using pidfile as...

### DIFF
--- a/files/agent.d/proviso-stats.conf
+++ b/files/agent.d/proviso-stats.conf
@@ -1,0 +1,3 @@
+# collect PROVISO metrics from Customer management interface
+UserParameter=custom.proviso.stats.cache[*],[ $((`date +%s` - `stat -L --format=%Y /var/lib/zabbix/custom.proviso.stats.CACHE 2>/dev/null || echo 0`)) -ge 60 ] && curl -s -m8 $1 2>/dev/null 1>/var/lib/zabbix/custom.proviso.stats.CACHE && ls -lsh /var/lib/zabbix/custom.proviso.stats.CACHE || ls -lsh /var/lib/zabbix/custom.proviso.stats.CACHE
+UserParameter=custom.proviso.stats[*],cat /var/lib/zabbix/custom.proviso.stats.CACHE | sed -ne '/"$2"/,/}/p' | grep '"value":' | grep -Po '\d+'

--- a/files/bin/redis_checks.sh
+++ b/files/bin/redis_checks.sh
@@ -10,7 +10,6 @@
 # This is by no means an exhaustive list.  It could be extended to report pubsub or other statistics.
 # Just fill in the gaps.
 
-PIDFILE=/var/run/redis/redis.pid
 PATH=/opt/zabbix/bin:$PATH:/usr/local/bin
 
 # $1 = Zabbix "key," or the redis INFO key whose value we want
@@ -30,11 +29,7 @@ else
 fi
 
 case "$1" in
-  "running"   	) if [ -e "${PIDFILE}" ]; then
-			RESULT=$(ps auwwx | grep $(cat ${PIDFILE}) | grep -c redis-server)
-	          else
-			RESULT=0
-	  	  fi 
+  "running") RESULT=$(ps auwwx | grep -v grep | grep -c redis-server)
 		  ;;
   "list_length"	) # We need a second arg here:
 		  if [ "x$2" = "x" ]; then


### PR DESCRIPTION
... zabbix user will NOT have permission to read redis pidfile

Where zabbix user is a non-admin user, it cannot read redis pidfile so any operation/command based on the pidfile will fail with error below:

```
$ sudo su zabbix -c '/etc/zabbix/bin/redis_checks.sh running'
cat: /var/run/redis/redis.pid: Permission denied
Usage: grep [OPTION]... PATTERN [FILE]...
Try `grep --help' for more information.
0
```
